### PR TITLE
Fix rebasing and copying of config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,19 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     # Clean packages
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && apt-get clean
 
-# Pre-download listed dependencies to take
-# advantage of Docker cache.
-RUN mkdir -p /go/src/Mail-Go
-WORKDIR /go/src/Mail-Go
-COPY get.sh /go/src/Mail-Go
+# We use Disconnnect24 as the name is hardcoded into patch's source code.
+WORKDIR /go/src/github.com/Disconnect24/Mail-Go
+COPY get.sh /go/src/github.com/Disconnect24/Mail-Go
 RUN sh get.sh
 
-# Copy the entire Mail-Go source into builder's source.
-COPY . .
+# Copy needed parts of the Mail-Go source into builder's source,
+COPY *.go ./
+COPY patch patch
+
 RUN go get ./...
 
 # Build to name "app".
 RUN GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o app .
 
 # Wait until there's an actual MySQL connection we can use to start.
-CMD ["dockerize", "-wait", "tcp://database:3306", "-timeout", "60s", "/go/src/Mail-Go/app"]
+CMD ["dockerize", "-wait", "tcp://database:3306", "-timeout", "60s", "/go/src/github.com/Disconnect24/Mail-Go/app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,14 @@ services:
       - ./schema/:/docker-entrypoint-initdb.d/:ro
   mail:
     build: .
-    # Mail-Go runs in /, and it looks for config in the current dir. Hence /config
     volumes:
-      - ./config:/config
+      - ./config:/go/src/github.com/Disconnect24/Mail-Go/config
     ports:
       # Container 80 -> Host 8080
       - "8080:80"
     # We must wait for the DB to import/etc before starting ourselves.
     depends_on:
       - "database"
-  restart: on-failure
-
+    restart: on-failure
 volumes:
   mail_data:


### PR DESCRIPTION
Previously, the app had to have hardcoded file path locations and additionally copied the entire config directory into a static image.

This means that, if wished, builds could be published on say Docker Hub.