### PR TITLE
Fix send cd code

### DIFF
--- a/send.go
+++ b/send.go
@@ -43,7 +43,7 @@ func Send(c *gin.Context) {
 	// Now check if it can be verified
 	isVerified, err := AuthForSend(c.PostForm("mlid"))
 	if err != nil {
-		ErrorResponse(c, 666, "Something weird happened.")
+		ErrorResponse(c, 551, "Something weird happened.")
 		utilities.LogError(ravenClient, "Error changing from authentication database.", err)
 		return
 	} else if !isVerified {


### PR DESCRIPTION
666 was just a placeholder error code that should've never been used. 551 is a "program bug" error which is more appropriate.