### PR TITLE
Fix encoding in database

### DIFF
--- a/check.go
+++ b/check.go
@@ -74,7 +74,7 @@ func Check(c *gin.Context) {
 
 		chlng, err := hex.DecodeString(c.PostForm("chlng"))
 		if err != nil {
-			utilities.LogError(ravenClient, "Unable to decode chlng string", err)
+			utilities.LogError(ravenClient, "Unable to decode chlng", err)
 		}
 
 		h := hmac.New(sha1.New, []byte(key))
@@ -121,8 +121,6 @@ func Check(c *gin.Context) {
 		// mailFlag needs to be not one, apparently.
 		// The Wii will refuse to check otherwise.
 		mailFlag = utilities.RandStringBytesMaskImprSrc(33) // This isn't how Nintendo did the mail flag, how they did it is currently unknown.
-	} else {
-		// mailFlag was already set to 0 above.
 	}
 
 	// https://github.com/RiiConnect24/Mail-Go/wiki/check.cgi for response format

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       MYSQL_USER: rc24
       MYSQL_PASSWORD: changeme
     ports:
-      - "3306:3306"
+      - 3306
     volumes:
       - mail_data:/var/lib/mysql
       - ./schema/:/docker-entrypoint-initdb.d/:ro
@@ -18,7 +18,7 @@ services:
       - ./config:/go/src/github.com/Disconnect24/Mail-GO/config
     ports:
       # Container 80 -> Host 8080
-      - "8080:80"
+      - "8080:8080"
     # We must wait for the DB to import/etc before starting ourselves.
     depends_on:
       - "database"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       MYSQL_USER: rc24
       MYSQL_PASSWORD: changeme
     ports:
-      - 3306
+      - "3306:3306"
     volumes:
       - mail_data:/var/lib/mysql
       - ./schema/:/docker-entrypoint-initdb.d/:ro
@@ -18,7 +18,7 @@ services:
       - ./config:/go/src/github.com/Disconnect24/Mail-GO/config
     ports:
       # Container 80 -> Host 8080
-      - "8080:8080"
+      - "8080:80"
     # We must wait for the DB to import/etc before starting ourselves.
     depends_on:
       - "database"

--- a/inbound_parse.go
+++ b/inbound_parse.go
@@ -33,7 +33,7 @@ func sendGridHandler(c *gin.Context) {
 	// Figure out who sent it.
 	fromAddress, err := mail.ParseAddress(c.PostForm("from"))
 	if err != nil {
-		log.Printf("given from address is invalid: %v", err)
+		log.Printf("Given from address is invalid: %v", err)
 		return
 	}
 
@@ -73,7 +73,7 @@ func sendGridHandler(c *gin.Context) {
 
 	wiiMail, err := FormulateMail(fromAddress.Address, toAddress, c.PostForm("subject"), text, attachedFile)
 	if err != nil {
-		log.Printf("error formulating mail: %v", err)
+		log.Printf("Error formulating mail: %v", err)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	if global.Debug {
 		log.Println("Connecting to MySQL...")
 	}
-	db, err = sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s",
+	db, err = sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&collation=utf8mb4_unicode_ci",
 		global.Username, global.Password, global.Host, global.Port, global.DBName))
 	if err != nil {
 		panic(err)

--- a/send.go
+++ b/send.go
@@ -128,8 +128,8 @@ func Send(c *gin.Context) {
 		// Replace all @wii.com references in the friend request email with our own domain.
 		// Format: w9004342343324713@wii.com <mailto:w9004342343324713@wii.com>
 		mailContents = strings.Replace(mailContents,
-			fmt.Sprintf("%s@wii.com <mailto:%s@wii.com>", senderID, senderID),
-			fmt.Sprintf("%s@%s <mailto:%s@%s>", senderID, global.SendGridDomain, senderID, global.SendGridDomain),
+			fmt.Sprintf("%s@wii.com", senderID),
+			fmt.Sprintf("%s@%s", senderID, global.SendGridDomain),
 			-1)
 
 		// We're done figuring out the mail, now it's time to act as needed.


### PR DESCRIPTION
Messages with emoji were not making it into the database. I figured this out by looking in the logs and @spotlightishere noticed these were emoji. Then I found [this article](https://hackernoon.com/today-i-learned-storing-emoji-to-mysql-with-golang-204a093454b7) that helped a lot.

As a result, messages with weird characters should work now.

Give them some claps on Medium!

EDIT: Ugh, should've pulled before committing. Sorry about that, git can be hard for me.